### PR TITLE
fix: nav dropdowns and theme preset application

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -214,15 +214,15 @@
   // ========================================
 
   // Theme preset configurations
-  // Each preset maps a motion style to its recommended palette
+  // Each preset maps a motion style to its recommended palette and default accent
   const themePresets = {
-    still: { motion: 'still', palette: 'mono' },        // Minimal, focused
-    serene: { motion: 'serene', palette: 'morandi' },   // Calm, muted
-    stream: { motion: 'stream', palette: 'subtle' },    // Modern, understated
-    flowing: { motion: 'flowing', palette: 'fluid' },   // Balanced, water-inspired
-    cascade: { motion: 'cascade', palette: 'pastel' },  // Friendly, soft
-    rapids: { motion: 'rapids', palette: 'bold' },      // Energetic, vibrant
-    tsunami: { motion: 'tsunami', palette: '80s' }      // Bold, retro impact
+    still: { motion: 'still', palette: 'mono', accent: '3' },        // Minimal, focused
+    serene: { motion: 'serene', palette: 'morandi', accent: '2' },   // Calm, muted sage
+    stream: { motion: 'stream', palette: 'subtle', accent: '2' },    // Modern teal
+    flowing: { motion: 'flowing', palette: 'fluid', accent: null },  // Auto from motion
+    cascade: { motion: 'cascade', palette: 'pastel', accent: '2' },  // Soft blue
+    rapids: { motion: 'rapids', palette: 'bold', accent: '1' },      // Electric coral
+    tsunami: { motion: 'tsunami', palette: '80s', accent: '1' }      // Hot pink
   };
 
   function setThemePreset(preset) {
@@ -233,11 +233,21 @@
     setMotion(config.motion);
     setPalette(config.palette);
 
+    // Apply accent (clear for fluid/auto, set for others)
+    if (config.accent) {
+      setAccentFromPalette(config.accent);
+    } else {
+      // Clear accent for auto mode (fluid palette)
+      document.documentElement.removeAttribute('data-accent');
+      localStorage.removeItem('fluid-accent');
+    }
+
     // Store the preset
     localStorage.setItem('fluid-preset', preset);
 
     // Update UI
     updateThemeCards();
+    updatePaletteSwatches();
   }
 
   function updateThemeCards() {

--- a/index.html
+++ b/index.html
@@ -289,6 +289,10 @@ nav: home
     background: linear-gradient(135deg, oklch(0.45 0.12 230) 0%, oklch(0.75 0.08 200) 100%);
   }
 
+  .theme-grid__item[data-theme="flowing"] .theme-grid__overlay {
+    background: linear-gradient(135deg, oklch(0.50 0.15 220) 0%, oklch(0.70 0.12 240) 100%);
+  }
+
   .theme-grid__item[data-theme="cascade"] .theme-grid__overlay {
     background: linear-gradient(135deg, oklch(0.60 0.15 160) 0%, oklch(0.85 0.10 140) 100%);
   }

--- a/src/core/base.css
+++ b/src/core/base.css
@@ -183,15 +183,16 @@
   }
 
   /* === Themed list markers ===
-     Each child theme gets a distinctive marker */
+     Each child theme gets a distinctive marker
+     Note: Uses :not([class]) to avoid overriding nav dropdowns and other styled lists */
 
   /* Still: Clean disc (default - minimal) */
-  [data-motion="still"] ul {
+  [data-motion="still"] ul:not([class]) {
     list-style-type: disc;
   }
 
   /* Serene: Open circle - elegant, understated */
-  [data-motion="serene"] ul {
+  [data-motion="serene"] ul:not([class]) {
     list-style-type: circle;
   }
 

--- a/src/core/tokens.css
+++ b/src/core/tokens.css
@@ -1188,6 +1188,16 @@
   --accent: var(--palette-accent-1);
 }
 
+/* Default accent fallbacks for each palette (when no explicit accent selected) */
+[data-palette="morandi"]:not([data-accent]) { --accent: var(--palette-2); }  /* Sage mist */
+[data-palette="bold"]:not([data-accent]) { --accent: var(--palette-1); }     /* Electric coral */
+[data-palette="pastel"]:not([data-accent]) { --accent: var(--palette-2); }   /* Powder blue */
+[data-palette="earth"]:not([data-accent]) { --accent: var(--palette-1); }    /* Terracotta */
+[data-palette="mono"]:not([data-accent]) { --accent: var(--palette-3); }     /* Medium gray */
+[data-palette="80s"]:not([data-accent]) { --accent: var(--palette-1); }      /* Hot pink */
+[data-palette="matrix"]:not([data-accent]) { --accent: var(--palette-1); }   /* Matrix green */
+[data-palette="subtle"]:not([data-accent]) { --accent: var(--palette-2); }   /* Muted teal */
+
 
 /* ========================================
    FULL THEME OVERRIDES


### PR DESCRIPTION
- Add :not([class]) to still/serene list styles to prevent overriding nav dropdown's list-style: none
- Update setThemePreset to apply accent colors (not just palette)
- Add CSS fallback accents for all palettes when no explicit accent is selected
- Add flowing theme duotone overlay style for completeness